### PR TITLE
Add attributes see | icon | fpi to SVRL. Don't generate empty Q{} in path

### DIFF
--- a/core/src/main/resources/xslt/1.0/compile-for-svrl.xsl
+++ b/core/src/main/resources/xslt/1.0/compile-for-svrl.xsl
@@ -55,7 +55,7 @@
     <xsl:param name="rule"/>
 
     <svrl:fired-rule>
-      <xsl:copy-of select="$rule/@id | $rule/@role | $rule/@flag"/>
+      <xsl:copy-of select="$rule/@id | $rule/@role | $rule/@flag | $rule/@see | $rule/@icon | $rule/@fpi"/>
       <attribute name="context">
         <xsl:value-of select="$rule/@context"/>
       </attribute>
@@ -81,7 +81,7 @@
       </call-template>
     </variable>
     <svrl:failed-assert location="{{normalize-space($location)}}">
-      <xsl:copy-of select="$assert/@role | $assert/@flag | $assert/@id"/>
+      <xsl:copy-of select="$assert/@role | $assert/@flag | $assert/@id | $assert/@see | $assert/@icon | $assert/@fpi"/>
       <attribute name="test">
         <xsl:value-of select="$assert/@test"/>
       </attribute>
@@ -108,7 +108,7 @@
       </call-template>
     </variable>
     <svrl:successful-report location="{{normalize-space($location)}}">
-      <xsl:copy-of select="$report/@role | $report/@flag | $report/@id"/>
+      <xsl:copy-of select="$report/@role | $report/@flag | $report/@id | $report/@see | $report/@icon | $report/@fpi"/>
       <attribute name="test">
         <xsl:value-of select="$report/@test"/>
       </attribute>

--- a/core/src/main/resources/xslt/2.0/svrl.xsl
+++ b/core/src/main/resources/xslt/2.0/svrl.xsl
@@ -50,7 +50,7 @@
   <xsl:template name="schxslt-api:fired-rule">
     <xsl:param name="rule" as="element(sch:rule)" required="yes"/>
     <svrl:fired-rule>
-      <xsl:sequence select="($rule/@id, $rule/@role, $rule/@flag)"/>
+      <xsl:sequence select="($rule/@id, $rule/@role, $rule/@flag, $rule/@see, $rule/@icon, $rule/@fpi)"/>
       <attribute name="context">
         <xsl:value-of select="$rule/@context"/>
       </attribute>
@@ -64,7 +64,7 @@
     </xsl:variable>
     <comment> <xsl:sequence select="normalize-space($message)"/> </comment>
     <svrl:suppressed-rule>
-      <xsl:sequence select="($rule/@id, $rule/@role, $rule/@flag)"/>
+      <xsl:sequence select="($rule/@id, $rule/@role, $rule/@flag, $rule/@see, $rule/@icon, $rule/@fpi)"/>
       <attribute name="context">
         <xsl:value-of select="$rule/@context"/>
       </attribute>
@@ -75,7 +75,7 @@
     <xsl:param name="assert" as="element(sch:assert)" required="yes"/>
     <xsl:param name="location-function" as="xs:string" required="yes" tunnel="yes"/>
     <svrl:failed-assert location="{{{$location-function}({($assert/@subject, $assert/../@subject, '.')[1]})}}">
-      <xsl:sequence select="($assert/@role, $assert/@flag, $assert/@id)"/>
+      <xsl:sequence select="($assert/@role, $assert/@flag, $assert/@id, $assert/@see, $assert/@icon, $assert/@fpi)"/>
       <attribute name="test">
         <xsl:value-of select="$assert/@test"/>
       </attribute>
@@ -89,7 +89,7 @@
     <xsl:param name="report" as="element(sch:report)" required="yes"/>
     <xsl:param name="location-function" as="xs:string" required="yes" tunnel="yes"/>
     <svrl:successful-report location="{{{$location-function}({($report/@subject, $report/../@subject, '.')[1]})}}">
-      <xsl:sequence select="($report/@role, $report/@flag, $report/@id)"/>
+      <xsl:sequence select="($report/@role, $report/@flag, $report/@id, $report/@see, $report/@icon, $report/@fpi)"/>
       <attribute name="test">
         <xsl:value-of select="$report/@test"/>
       </attribute>


### PR DESCRIPTION
1. I absolutely miss support for attribute ```see```, but it seems fair to also include fpi and icon as those are legal schematron things to specify and might serve purpose somewhere. This PR add support for attributes ```see```,``` icon``` and ```fpi``` if specified.

1. A location like 
    ```/Q{}decor[1]/Q{}datasets[1]/Q{}dataset[1]/Q{}concept[1]``` 
is a lot less readable than 
   ```/decor[1]/datasets[1]/dataset[1]/concept[1] ``` 
while having the same power of expression. This PR also updates the path generation logic to omit Q{} when there is no namespace-uri