### PR TITLE
Fix copying of attribute values from content of sch:let into xsl:param

### DIFF
--- a/core/src/main/resources/xslt/1.0/compile/compile-1.0.xsl
+++ b/core/src/main/resources/xslt/1.0/compile/compile-1.0.xsl
@@ -256,7 +256,7 @@
 
   <xsl:template match="@*" mode="schxslt:variable-content">
     <attribute namespace="{namespace-uri(.)}" name="{local-name(.)}">
-      <value-of select="."/>
+      <xsl:value-of select="."/>
     </attribute>
   </xsl:template>
 

--- a/core/src/main/resources/xslt/2.0/compile/templates.xsl
+++ b/core/src/main/resources/xslt/2.0/compile/templates.xsl
@@ -59,7 +59,7 @@
 
   <xsl:template match="@*" mode="schxslt:variable-content schxslt:message-template">
     <attribute namespace="{namespace-uri(.)}" name="{local-name(.)}">
-      <value-of select="."/>
+      <xsl:value-of select="."/>
     </attribute>
   </xsl:template>
 


### PR DESCRIPTION
This pull request fixes an issue with the copying of attribute values from the content of sch:let into xsl:param.

For example, this sch:let:

```xml
    <sch:let name="mediaExtensions">
        <media ext=".zip" mime="application/zip">Zip Compressed File</media>
        <media ext=".doc" mime="application/msword">Microsoft Word .doc</media>
    </sch:let>
```

SchXslt version 1.7.2 transforms the above sch:let into this xsl:param. The attribute values are lost, and this results in errors when trying to run the compiled Schematron.

```xml
   <xsl:param name="mediaExtensions">
      <xsl:element namespace="" name="media">
         <xsl:attribute namespace="" name="ext">
            <xsl:value-of select="."/>
         </xsl:attribute>
         <xsl:attribute namespace="" name="mime">
            <xsl:value-of select="."/>
         </xsl:attribute>Zip Compressed File</xsl:element>
      <xsl:element namespace="" name="media">
         <xsl:attribute namespace="" name="ext">
            <xsl:value-of select="."/>
         </xsl:attribute>
         <xsl:attribute namespace="" name="mime">
            <xsl:value-of select="."/>
         </xsl:attribute>Microsoft Word .doc</xsl:element>
   </xsl:param>
```

This pull request fixes the transformation to preserve attribute values, and produces this xsl:param.

```xml
   <xsl:param name="mediaExtensions">
      <xsl:element namespace="" name="media">
         <xsl:attribute namespace="" name="ext">.zip</xsl:attribute>
         <xsl:attribute namespace="" name="mime">application/zip</xsl:attribute>Zip Compressed File</xsl:element>
      <xsl:element namespace="" name="media">
         <xsl:attribute namespace="" name="ext">.doc</xsl:attribute>
         <xsl:attribute namespace="" name="mime">application/msword</xsl:attribute>Microsoft Word .doc</xsl:element>
   </xsl:param>
```
