### PR TITLE
Fix to prevent an error when a generated id is processed more than once

### DIFF
--- a/core/src/main/resources/xslt/2.0/compile/compile-2.0.xsl
+++ b/core/src/main/resources/xslt/2.0/compile/compile-2.0.xsl
@@ -221,7 +221,7 @@
 
       <schxslt:rule pattern="{generate-id(..)}">
         <choose>
-          <when test="$schxslt:patterns-matched[. = '{generate-id(..)}']">
+          <when test="$schxslt:patterns-matched[. = '{generate-id(..)}'][1]">
             <xsl:call-template name="schxslt-api:suppressed-rule">
               <xsl:with-param name="rule" as="element(sch:rule)" select="."/>
             </xsl:call-template>


### PR DESCRIPTION
When using SchXslt version 1.7.3 an error occurs if $schxslt:patterns-matched contains a generated ID value more than once. This produces an error message: 

Type error evaluating ($schxslt:patterns-matched[. eq "d17e3833"]) in xsl:when/@test on line 1668 column 482 of schematron-compiled.xsl:
  FORG0006: Effective boolean value is not defined for a sequence of two or more items starting with a string

This problem is demonstrated by this Schematron:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
    <sch:pattern>
        <sch:rule context="p">
            <sch:assert test="contains(., 'A')">contains 'A'</sch:assert>
        </sch:rule>
        <sch:rule context="sec/p">
            <sch:assert test="contains(., 'B')">contains 'B'</sch:assert>
        </sch:rule>
        <sch:rule context="p[@type = 'summary']">
            <sch:assert test="contains(., 'C')">contains 'C'</sch:assert>
        </sch:rule>
    </sch:pattern>
</sch:schema>
```

and this XML document:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<article>
    <sec>
        <p>text A</p>
        <p>text B</p>
        <p>text C</p>
    </sec>
    <sec>
        <p type="summary">text A</p>
        <p type="summary">text B</p>
        <p type="summary">text C</p>
    </sec>
</article>
```

This pull request adds a predicate [1] in the `when test` to prevent the error.

```xml
<when test="$schxslt:patterns-matched[. = '{generate-id(..)}'][1]">
```

This problem does not occur on the master branch. It looks like there are some previous changes made in compile-2.0.xsl on 1 April 2021 in the master branch that did not make it onto the 1.7.3 release. This change to add a predicate in the `when test` can also be made to compile-2.0.xsl in the master branch but git will not perform the merge automatically.