### PR TITLE
Fix to prevent an error when a generated id is processed more than once

### DIFF
--- a/core/src/main/resources/xslt/2.0/compile/compile-2.0.xsl
+++ b/core/src/main/resources/xslt/2.0/compile/compile-2.0.xsl
@@ -220,7 +220,7 @@
       </xsl:call-template>
 
       <choose>
-        <when test="$schxslt:patterns-matched[. = '{generate-id(..)}']">
+        <when test="$schxslt:patterns-matched[. = '{generate-id(..)}'][1]">
           <schxslt:rule pattern="{generate-id(..)}">
             <xsl:call-template name="schxslt-api:suppressed-rule">
               <xsl:with-param name="rule" as="element(sch:rule)" select="."/>


### PR DESCRIPTION
This pull request is the same fix in pull request #202 applied to the master branch.