### PR TITLE
Fix for missing @xml:* Attributes in SVRL

### DIFF
--- a/core/src/main/resources/xslt/2.0/svrl.xsl
+++ b/core/src/main/resources/xslt/2.0/svrl.xsl
@@ -27,7 +27,7 @@
         </xsl:if>
         <xsl:for-each select="$schema/sch:p">
           <svrl:text>
-            <xsl:sequence select="(@id, @class, @icon)"/>
+            <xsl:sequence select="(@id, @class, @icon, @xml:*)"/>
             <xsl:apply-templates select="node()" mode="schxslt:message-template"/>
           </svrl:text>
         </xsl:for-each>
@@ -51,7 +51,7 @@
         <xsl:if test="exists($pattern/sch:title | $pattern/@id)">
           <xsl:attribute name="name" select="($pattern/sch:title, $pattern/@id)[1]"/>
         </xsl:if>
-        <xsl:sequence select="($pattern/@id, $pattern/@role)"/>
+        <xsl:sequence select="($pattern/@id, $pattern/@role, $pattern/@xml:*)"/>
         <attribute name="documents" select="base-uri(.)"/>
       </svrl:active-pattern>
     </xsl:if>
@@ -61,7 +61,7 @@
     <xsl:param name="rule" as="element(sch:rule)" required="yes"/>
     <xsl:if test="$schxslt.svrl.compact eq false()">
       <svrl:fired-rule>
-        <xsl:sequence select="($rule/@id, $rule/@role, $rule/@flag, $rule/@see, $rule/@icon, $rule/@fpi)"/>
+        <xsl:sequence select="($rule/@id, $rule/@role, $rule/@flag, $rule/@see, $rule/@icon, $rule/@fpi, $rule/@xml:*)"/>
         <attribute name="context">
           <xsl:value-of select="$rule/@context"/>
         </attribute>
@@ -89,7 +89,7 @@
     <xsl:param name="assert" as="element(sch:assert)" required="yes"/>
     <xsl:param name="location-function" as="xs:string" required="yes" tunnel="yes"/>
     <svrl:failed-assert location="{{{$location-function}({($assert/@subject, $assert/../@subject, '.')[1]})}}">
-      <xsl:sequence select="($assert/@role, $assert/@flag, $assert/@id, $assert/@see, $assert/@icon, $assert/@fpi)"/>
+      <xsl:sequence select="($assert/@role, $assert/@flag, $assert/@id, $assert/@see, $assert/@icon, $assert/@fpi, $assert/@xml:*)"/>
       <attribute name="test">
         <xsl:value-of select="$assert/@test"/>
       </attribute>
@@ -103,7 +103,7 @@
     <xsl:param name="report" as="element(sch:report)" required="yes"/>
     <xsl:param name="location-function" as="xs:string" required="yes" tunnel="yes"/>
     <svrl:successful-report location="{{{$location-function}({($report/@subject, $report/../@subject, '.')[1]})}}">
-      <xsl:sequence select="($report/@role, $report/@flag, $report/@id, $report/@see, $report/@icon, $report/@fpi)"/>
+      <xsl:sequence select="($report/@role, $report/@flag, $report/@id, $report/@see, $report/@icon, $report/@fpi, $report/@xml:*)"/>
       <attribute name="test">
         <xsl:value-of select="$report/@test"/>
       </attribute>
@@ -158,6 +158,7 @@
     <xsl:call-template name="schxslt:copy-properties"/>
     <xsl:if test="text() | *">
       <svrl:text>
+        <xsl:sequence select="@xml:*"/>
         <xsl:apply-templates select="node()" mode="schxslt:message-template"/>
       </svrl:text>
     </xsl:if>
@@ -166,7 +167,7 @@
   <xsl:template name="schxslt:handle-property">
     <xsl:param name="property" as="element(sch:property)"/>
     <svrl:property-reference property="{.}">
-      <xsl:sequence select="($property/@role, $property/@scheme)"/>
+      <xsl:sequence select="($property/@role, $property/@scheme, $property/@xml:*)"/>
       <svrl:text>
         <xsl:apply-templates select="$property/node()" mode="schxslt:message-template">
           <xsl:with-param name="allow-xsl-copy-of" tunnel="yes" as="xs:boolean" select="true()"/>
@@ -203,6 +204,7 @@
     <xsl:for-each select="tokenize(@diagnostics, ' ')">
       <xsl:variable name="diagnostic" select="($pattern/sch:diagnostics/sch:diagnostic[@id eq current()] | $pattern/../sch:diagnostics/sch:diagnostic[@id eq current()])[1]"/>
       <svrl:diagnostic-reference diagnostic="{.}">
+        <xsl:sequence select="$diagnostic/@xml:*"/>
         <svrl:text>
           <xsl:sequence select="$diagnostic/@*"/>
           <xsl:apply-templates select="$diagnostic/node()" mode="schxslt:message-template"/>
@@ -213,6 +215,7 @@
 
   <xsl:template match="sch:dir | sch:emph | sch:span" mode="schxslt:message-template">
     <xsl:element name="svrl:{local-name()}">
+      <xsl:sequence select="@xml:*"/>
       <xsl:apply-templates select="node() | @*" mode="#current"/>
     </xsl:element>
   </xsl:template>


### PR DESCRIPTION
In the SVRL file attributes in xml-Namespace (@xml:*) are currently missing with the exception of sch:diagnostics.

Fix provided to get @xml:* attributes in other SVRL Elements too.

