### PR TITLE
Bump spotbugs-maven-plugin to 4.7.3.0

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -73,7 +73,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.2.0</version>
+        <version>4.7.3.0</version>
         <configuration>
           <effort>Max</effort>
           <threshold>Low</threshold>


### PR DESCRIPTION
It can help to fix schxslt building with JDK 20.

See https://github.com/spotbugs/spotbugs/releases/tag/4.7.3 for details.

Fixes: https://github.com/schxslt/schxslt/issues/297.